### PR TITLE
Fix min-neighbor KDTree frame selection

### DIFF
--- a/geodesic_interpolate/coord_utils.py
+++ b/geodesic_interpolate/coord_utils.py
@@ -89,10 +89,10 @@ def get_bond_list(geom, atoms=None, threshold=4, min_neighbors=4, snapshots=30, 
     # Get neighbor list for included geometry and merge them
     rijset = set(enforce)
     for image in images:
-        tree = KDTree(geom[image])
-        pairs = tree.query_pairs(threshold)
+        image_tree = KDTree(geom[image])
+        pairs = image_tree.query_pairs(threshold)
         rijset.update(pairs)
-        bonded = tree.query_pairs(bond_threshold)
+        bonded = image_tree.query_pairs(bond_threshold)
         neighbors = {i: {i} for i in range(geom.shape[1])}
         for i, j in bonded:
             neighbors[i].add(j)
@@ -110,9 +110,11 @@ def get_bond_list(geom, atoms=None, threshold=4, min_neighbors=4, snapshots=30, 
     for i, j in rijlist:
         count[i] += 1
         count[j] += 1
+    final_geom = geom[-1]
+    final_tree = KDTree(final_geom)
     for idx, ct in enumerate(count):
         if ct < min_neighbors:
-            _, neighbors = tree.query(geom[-1, idx], k=min_neighbors + 1)
+            _, neighbors = final_tree.query(final_geom[idx], k=min_neighbors + 1)
             for i in neighbors:
                 if i == idx:
                     continue

--- a/tests/test_coord_utils.py
+++ b/tests/test_coord_utils.py
@@ -1,0 +1,34 @@
+import unittest
+
+import numpy as np
+
+from geodesic_interpolate.coord_utils import get_bond_list
+
+
+class CoordUtilsTest(unittest.TestCase):
+    def test_get_bond_list_min_neighbors_uses_final_frame_tree(self):
+        geom = np.array([
+            [[100.0, 100.0, 0.0], [101.0, 100.0, 0.0],
+             [102.0, 100.0, 0.0], [103.0, 100.0, 0.0]],
+            [[100.0, 0.0, 0.0], [101.0, 0.0, 0.0],
+             [0.0, 0.0, 0.0], [10.0, 0.0, 0.0]],
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0],
+             [10.0, 0.0, 0.0], [11.0, 0.0, 0.0]],
+        ])
+
+        pairs, _ = get_bond_list(
+            geom,
+            threshold=0.1,
+            bond_threshold=0.1,
+            min_neighbors=1,
+            snapshots=3,
+        )
+
+        self.assertEqual(
+            [(int(i), int(j)) for i, j in pairs],
+            [(0, 1), (2, 3)],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem statement
`get_bond_list()` completed `min_neighbors` by querying final-frame points against the last KDTree left over from sampled-frame screening. When an interior sampled frame was processed after the final frame, nearest-neighbor completion could add pairs that are far apart in the final geometry.

Fixes #14.

## Description of solution
- Keep sampled-frame KDTrees scoped to threshold and bond-neighborhood discovery.
- Build a dedicated final-frame KDTree for the `min_neighbors` completion pass.
- Add a deterministic regression test where the stale middle-frame tree previously selected long final-frame pairs.

## Validation
- Numeric regression probe: mean per-atom shortest selected-neighbor distance improved from `9.5` before the fix to `1.0` after; exact expected-pair match improved from `0` to `1`.
- `./.venv/bin/python -m unittest discover -v` -> 9 tests OK.
- Three independent subagent review passes found no issues in implementation, test determinism, or scope.